### PR TITLE
Fix seo metadata

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,8 +16,8 @@
 :page-permalink: /guides/{projectid}
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
 :source-highlighter: prettify
-:seo-title: Open Liberty tutorial
-:seo-description: Find out how to run microservices on Open Liberty 
+:page-seo-title: Open Liberty tutorial
+:page-seo-description: Find out how to run microservices on Open Liberty 
 = Getting started with the Open Liberty application server
 
 [.hidden]


### PR DESCRIPTION
The metadata needs `page-` so that Jekyll can pick up the information when building the `<head>` of the guide page.